### PR TITLE
Fixed debug being built with release configuration

### DIFF
--- a/MergePDF.sln
+++ b/MergePDF.sln
@@ -11,8 +11,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{8BF6B775-F54A-4590-959B-FD6D5AEC1280}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{8BF6B775-F54A-4590-959B-FD6D5AEC1280}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{8BF6B775-F54A-4590-959B-FD6D5AEC1280}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BF6B775-F54A-4590-959B-FD6D5AEC1280}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8BF6B775-F54A-4590-959B-FD6D5AEC1280}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8BF6B775-F54A-4590-959B-FD6D5AEC1280}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection


### PR DESCRIPTION
Looks like Debug and Release options are using Release as configuration. Makes hard to debug, changed Debug configuration to use Debug.